### PR TITLE
Create resources via EB extensions. Update to supported platform.

### DIFF
--- a/.ebextensions/dynamodb-tables.config
+++ b/.ebextensions/dynamodb-tables.config
@@ -1,0 +1,75 @@
+Resources:
+  UserTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: scorekeep-user
+      KeySchema:
+        HashKeyElement: {AttributeName: id, AttributeType: S}
+      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
+  SessionTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: scorekeep-session
+      KeySchema:
+        HashKeyElement: {AttributeName: id, AttributeType: S}
+      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
+  GameTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: scorekeep-game
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+        - AttributeName: "session"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        - IndexName: "session-index"
+          KeySchema:
+            - AttributeName: "session"
+              KeyType: "HASH"
+          ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
+          Projection: { ProjectionType: ALL }
+      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
+  MoveTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: scorekeep-move
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+        - AttributeName: "game"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        - IndexName: "game-index"
+          KeySchema:
+            - AttributeName: "game"
+              KeyType: "HASH"
+          ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
+          Projection: { ProjectionType: ALL }
+      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
+  StateTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: scorekeep-state
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+        - AttributeName: "game"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        - IndexName: "game-index"
+          KeySchema:
+            - AttributeName: "game"
+              KeyType: "HASH"
+          ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
+          Projection: { ProjectionType: ALL }
+      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}

--- a/.ebextensions/env.config
+++ b/.ebextensions/env.config
@@ -1,0 +1,5 @@
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    AWS_REGION: '`{"Ref" : "AWS::Region"}`'
+    NOTIFICATION_TOPIC: '`{"Ref" : "NotificationTopic"}`'
+    NOTIFICATION_EMAIL: UPDATE_ME

--- a/.ebextensions/sns-topic.config
+++ b/.ebextensions/sns-topic.config
@@ -1,0 +1,8 @@
+Resources:
+  NotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: scorekeep-sns-topic
+      Subscription:
+      - Endpoint: nobody@example.com
+        Protocol: email

--- a/.ebextensions/sns-topic.config
+++ b/.ebextensions/sns-topic.config
@@ -3,6 +3,3 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: scorekeep-sns-topic
-      Subscription:
-      - Endpoint: nobody@example.com
-        Protocol: email

--- a/template.yml
+++ b/template.yml
@@ -21,34 +21,10 @@ Resources:
       ApplicationName: !Ref application
       EnvironmentName: BETA
       OptionSettings:
-        - Namespace: aws:elasticbeanstalk:application:environment
-          OptionName: AWS_REGION
-          Value: !Ref AWS::Region
-        - Namespace: aws:elasticbeanstalk:application:environment
-          OptionName: NOTIFICATION_TOPIC
-          Value: !Ref notificationTopic
-        - Namespace: aws:elasticbeanstalk:application:environment
-          OptionName: NOTIFICATION_EMAIL
-          Value: !Ref emailAddress
-        - Namespace: aws:elasticbeanstalk:application:environment
-          OptionName: USER_TABLE
-          Value: !Ref userTable
-        - Namespace: aws:elasticbeanstalk:application:environment
-          OptionName: SESSION_TABLE
-          Value: !Ref sessionTable
-        - Namespace: aws:elasticbeanstalk:application:environment
-          OptionName: GAME_TABLE
-          Value: !Ref gameTable
-        - Namespace: aws:elasticbeanstalk:application:environment
-          OptionName: MOVE_TABLE
-          Value: !Ref moveTable
-        - Namespace: aws:elasticbeanstalk:application:environment
-          OptionName: STATE_TABLE
-          Value: !Ref stateTable
         - Namespace: aws:autoscaling:launchconfiguration
           OptionName: IamInstanceProfile
           Value: !Ref instanceProfile
-      PlatformArn: arn:aws:elasticbeanstalk:::platform/Java 8 running on 64bit Amazon Linux
+      PlatformArn: arn:aws:elasticbeanstalk:::platform/Corretto 8 running on 64bit Amazon Linux 2
       VersionLabel: !Ref version
   instanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -99,77 +75,6 @@ Resources:
                 Effect: Allow
                 Resource: '*'
       Path: /
-  notificationTopic:
-    Type: AWS::SNS::Topic
-  userTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      KeySchema:
-        HashKeyElement: {AttributeName: id, AttributeType: S}
-      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
-  sessionTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      KeySchema:
-        HashKeyElement: {AttributeName: id, AttributeType: S}
-      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
-  gameTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      AttributeDefinitions:
-        - AttributeName: "id"
-          AttributeType: "S"
-        - AttributeName: "session"
-          AttributeType: "S"
-      KeySchema:
-        - AttributeName: "id"
-          KeyType: "HASH"
-      GlobalSecondaryIndexes:
-        - IndexName: "session-index"
-          KeySchema:
-            - AttributeName: "session"
-              KeyType: "HASH"
-          ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
-          Projection: { ProjectionType: ALL }
-      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
-  moveTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      AttributeDefinitions:
-        - AttributeName: "id"
-          AttributeType: "S"
-        - AttributeName: "game"
-          AttributeType: "S"
-      KeySchema:
-        - AttributeName: "id"
-          KeyType: "HASH"
-      GlobalSecondaryIndexes:
-        - IndexName: "game-index"
-          KeySchema:
-            - AttributeName: "game"
-              KeyType: "HASH"
-          ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
-          Projection: { ProjectionType: ALL }
-      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
-  stateTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      AttributeDefinitions:
-        - AttributeName: "id"
-          AttributeType: "S"
-        - AttributeName: "game"
-          AttributeType: "S"
-      KeySchema:
-        - AttributeName: "id"
-          KeyType: "HASH"
-      GlobalSecondaryIndexes:
-        - IndexName: "game-index"
-          KeySchema:
-            - AttributeName: "game"
-              KeyType: "HASH"
-          ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
-          Projection: { ProjectionType: ALL }
-      ProvisionedThroughput: {ReadCapacityUnits: 2, WriteCapacityUnits: 2}
 Outputs:
   endpoint:
     Description: Website URL


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/eb-java-scorekeep/issues/16, https://github.com/aws-samples/eb-java-scorekeep/issues/17

*Description of changes:*
The packaged version of the scorekeep app is outdated. As mentioned in above issues, it is incompatible with EB and the build fails. The code in this branch is slightly up to date and builds fine but lacks the AWS resources needed for the app to work when uploaded to EB manually.
This PR:
- Creates DDB tables and SNS topic as eb extension rather than CFN template to work with manual code upload process.
- Updated the template to use the Corretto 8. platform since Java 8 is now unsupported.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
